### PR TITLE
Add “Contrast” to Accessibility Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Principle, Framer, Invision Studio, Flinto are also among UI & UX animation apps
 * [Hex Naw](https://hexnaw.com/) —  helps you to test entire color systems for contrast and accessibility. 
 * [PA11Y](http://pa11y.org/) — accessibility testing tool to find issues with your web pages. It runs HTML CodeSniffer from the command line for programmatic accessibility reporting.
 * [Sim Daltonism](https://michelf.ca/projects/sim-daltonism/) — a color blindness simulator for macOS and iOS that lets you visualize colors as they are perceived with various types of color blindness. It‘s free and [open-source](https://www.github.com/michelf/sim-daltonism/).
+* [Contrast](https://usecontrast.com/) — a macOS app for designers and developers to get quick access to WCAG color contrast ratios.
 
 ### Augmented Reality Tools
 * [Lightform](https://lightform.com/) — design tool for projected AR.

--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Principle, Framer, Invision Studio, Flinto are also among UI & UX animation apps
  
 ### Accessibility Tools
 * [Contraste](https://contrasteapp.com/) — app for checking the accessibility of text against the Web Content Accessibility Guidelines (WCAG).
+* [Contrast](https://usecontrast.com/) — a macOS app for designers and developers to get quick access to WCAG color contrast ratios.
 * [Hex Naw](https://hexnaw.com/) —  helps you to test entire color systems for contrast and accessibility. 
 * [PA11Y](http://pa11y.org/) — accessibility testing tool to find issues with your web pages. It runs HTML CodeSniffer from the command line for programmatic accessibility reporting.
 * [Sim Daltonism](https://michelf.ca/projects/sim-daltonism/) — a color blindness simulator for macOS and iOS that lets you visualize colors as they are perceived with various types of color blindness. It‘s free and [open-source](https://www.github.com/michelf/sim-daltonism/).
-* [Contrast](https://usecontrast.com/) — a macOS app for designers and developers to get quick access to WCAG color contrast ratios.
 
 ### Augmented Reality Tools
 * [Lightform](https://lightform.com/) — design tool for projected AR.


### PR DESCRIPTION
This adds [Contrast](https://usecontrast.com/) to the accessibility tools section. 