### PR TITLE
Added px.div 

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ We can also add to this list Sketch and Figma, which are mentioned in UI design 
 * [Bootstrap Studio](https://bootstrapstudio.io/) — a powerful web design tool for creating responsive websites using the Bootstrap framework.
 * [Mobirise](https://mobirise.com/) — an offline drag and drop website builder software that is based on Bootstrap 3/4 and Google AMP. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
 * [Pinegrow](https://pinegrow.com/) — a professional visual editor for CSS Grid, Bootstrap 4 and 3, Foundation, responsive design, HTML, and CSS.
+* [px.div](https://www.pxdiv.com) — Proper site build tool for developers and designers.
 * [Readymag](https://readymag.com/) — a visually-pleasing tool for designing on the web from landing pages to multimedia long-reads, presentations and portfolios.
 * [STUDIO](https://studio.design/) — design from scratch, collaborate in real time and publish websites.
 * [Sympli](https://sympli.io/) — deliver the design, assets, specifications directly into your preferred IDE (e.g Xcode, Android Studio).


### PR DESCRIPTION
I've added [**px.div**](https://www.pxdiv.com) a web design SaaS tool (recently lunched).

Description from the product hunt page:
> I've created px.div to help developers and designers build HTML and CSS visually while keeping the same feel of the hand coded development process (there are no abstractions over CSS, interface elements represents CSS properties and values). Projects can be exported with all of the pages (as HTML), CSS and assets (images) as a ZIP file ready for development.