### PR TITLE
Fix banner for handoff, fonts and icons sections. Add Specify inside icons and fonts sections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Everyone can learn development but it takes time and effort. If you need a websi
 
 <div class="banner banner--yellow">
 
+You can also do design to code with Specify, which is mentioned in the Design System Tools section.
+
 </div>
 
 </article>
@@ -389,6 +391,8 @@ Fonts are commonly used for making the web a more beautiful place. It’s an ess
 * [Webfont](https://webfontapp.com/) — create and maintain custom SVG icon fonts, made a shared library of icons. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg) ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
 
 <div class="banner banner--yellow">
+
+You can also handle fonts with Specify, which is mentioned in the Design System Tools section.
 
 </div>
 
@@ -453,6 +457,8 @@ As well as fonts, icons are used in every design. These basic elements support a
 * [Zwicon](https://www.zwicon.com/) — handcrafted iconset for your next project. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
 
 <div class="banner banner--yellow">
+
+You can also handle icons with Specify, which is mentioned in the Design System Tools section.
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -240,12 +240,6 @@ Design handoff happens when designers finish the work and need to deliver design
 * [Sympli](https://sympli.io) — automated specs and assets handoff from Sketch, Photoshop and Adobe XD. Integrated with Jira, Xcode and Android Studio.
 * [Zeplin](https://zeplin.io/) — handoff designs and styleguides with accurate specs, assets, code snippets automatically.
 
-<div class="banner banner--yellow">
-
-You can also do handoff with Specify, which is mentioned in the Design System Tools section.
-
-</div>
-
 </article>
 
 <article id="design-inspiration">
@@ -324,12 +318,6 @@ Everyone can learn development but it takes time and effort. If you need a websi
 * [Tilda](https://tilda.cc/) — create a website, landing page or online store for free with the help of Tilda modules and publish it on the same day.
 * [Wix](https://www.wix.com/) — the easiest and fullest-featured website builder, that allows you to create your own highly customized site.
 * [Webflow](https://webflow.com/) — build responsive websites in your browser, then host with us or export your code to host wherever.
-
-<div class="banner banner--yellow">
-
-You can also do design to code with Specify, which is mentioned in the Design System Tools section.
-
-</div>
 
 </article>
 


### PR DESCRIPTION
Hi @valianka ! Thanks for reviewing [my last PR](https://github.com/LisaDziuba/Awesome-Design-Tools/pull/146). I understand you don't want a tool to appear in too much topics. My understanding is that you want to restrain a tool to one primary section and one secondary one to prevent flood and advertising abuse. 

However I added Specify to the "icons" and "fonts" secondary sections because to my eyes our tool really fits in them.

Here's why: we allow people to set and share basic interface elements like colors, icons, font files and text styles. All these elements are converted to code by Specify and can be exported. You can see Specify as a mix between Iconjar, RightFont and a design tokens manager.

I just wanted to be more clear about why I put Specify in all of these secondary sections.

Thanks again 😉