### PR TITLE
Add SAP Build Prototyping tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ A prototype is a simple experimental design of a proposed solution. It should he
 * [Alva](https://www.meetalva.io/) — create living prototypes with code components. It's also open source. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg) [![open-source.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/open-source.svg)](https://github.com/meetalva/alva)
 * [Axure RP](https://www.axure.com/) — wireframing, prototyping, collaboration & specifications generation.
 * [Balsamiq](https://balsamiq.com/) — wireframing and collaboration.
+* [SAP Build](https://www.build.me/) — a complete set of cloud‑based tools to design and build your enterprise app.
 * [Creo](https://creolabs.com/) — prototyping, code exporting and built-in mobile app builder. ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
 * [InVision](https://www.invisionapp.com/) — prototyping, collaboration & workflow platform. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
 * [Flinto](https://www.flinto.com/) — a Mac app for creating interactive and animated prototypes of app designs.


### PR DESCRIPTION
SAP Build is a complete set of cloud‑based tools to design and build your enterprise app.
- Create clickable mockups of your application from your sketches. Then turn them into refined prototypes and bring them to life by dragging and dropping real SAP UI5 elements.
- Understand your users’ needs. Collect informal feedback or easily create remote usability studies on each iteration of your design. SAP Build makes it easy to bring users into the design process.

A video of the product is available here: https://vimeo.com/182832619

https://www.build.me/

## Checklist

* [x] I made something good today 💐.
* [x] I put links in the correct format: ``[Tool](link) — description.``
* [x] My description starts with the lower-case letter and ends with the full stop.
* [x] I put the tool in the alphabetical order.

## Optional

* [x] I added the appropriate labels: free, open-source or mac.
* [x] I put the tool only to one category.
* [x] I followed [Contribution Guidelines](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Contribution_Guidelines.md#one-tool-can-go-only-to-one-category). 

