### PR TITLE
Add Nextcloud to collaboration tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Looking to try some tools for agile design and development collaboration? Good i
 * [Milanote](https://milanote.com/) — an easy-to-use, collaborative tool to organize your ideas and projects into visual boards.
 * [Mixed](https://mixed.io) — real-time whiteboard and collaboration tools for distributed teams. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
 * [MURAL](https://mural.co/) — think and collaborate visually. Anywhere, anytime.
+* [Nextcloud](https://nextcloud.com) — open source collaboration platform for files, kanban boards, chat & calls, calendar and more. ![open-source.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/open-source.svg) ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
 * [Notion](https://www.notion.so) — write, plan, collaborate, and get organized. Notion is all you need — in one tool.
 * [ProofHub](https://www.proofhub.com/) — the one place for all your projects, teams and communications.
 * [RealtimeBoard (Miro)](https://www.realtimeboard.com/) — whiteboarding platform for cross-functional team collaboration. It was recently renaimed to Miro.


### PR DESCRIPTION
[Nextcloud](https://nextcloud.com) is basically Google Apps in open source with lots of collaboration apps. Added the 'free' label too because people can simply sign up at https://nextcloud.com/signup/

Thanks for this cool list, and cheers from [Open Source Design](https://opensourcedesign.net) :)

## Checklist

* [x] I made something good today 💐.
* [x] I put links in the correct format: ``[Tool](link) — description.``
* [x] My description starts with the lower-case letter and ends with the full stop.
* [x] I put the tool in the alphabetical order.

## Optional

* [x] I added the appropriate labels: free, open-source or mac.
* [x] I put the tool only to one category.
* [x] I followed [Contribution Guidelines](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Contribution_Guidelines.md#one-tool-can-go-only-to-one-category). 

