### PR TITLE
fix link to category

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you found some great design tool, just send a Pull Request with respect to ou
 * [Design System Tools](#design-system-tools)
 * [Design to Code Tools](#design-to-code-tools)
 * [Design Version Control](#design-version-control)
-* [Development browsers](#developer-browsers)
+* [Development browsers](#development-browsers)
 * [Experience Monitoring](#experience-monitoring)
 * [Font Tools](#font-tools)
 * [Gradient Tools](#gradient-tools)


### PR DESCRIPTION
The link to the category 'development browsers' was wrong (my bad). The page https://flawlessapp.io/designtools#development-browsers also has "Fundefined" as the icon for Firefox Developer Edition and I don't know how to fix that.