### PR TITLE
fix: text logo for titles with only one uppercase letter

### DIFF
--- a/docs/modules/tweakToolContainer.js
+++ b/docs/modules/tweakToolContainer.js
@@ -3,19 +3,15 @@ const capitalizeFirstLetter = (string) => (
 );
 
 const makeTextLogo = (unsplittedTitle) => {
-	const titleObject = unsplittedTitle.split('>')[1].split('</a')[0].split(' ');
-	if (titleObject.length === 1) {
-		return titleObject[0].slice(0, 1);
-	}
-	let result = [];
-	titleObject.map((word) => {
-		if (word === titleObject[0]) {
-			result.push(word[0])
-		} else if (word[0].toUpperCase() === word[0]) {
-			result.push(word[0]);
-		}
-	})
-	return result[0] + result[1];
+	const words = unsplittedTitle.split('>')[1].split('</a')[0].split(' ');
+	
+	const result = words
+		.map(word => word[0])
+		.filter(character => character === character.toUpperCase())
+		.slice(0, 2)
+		.join('');
+
+	return result;
 }
 
 const createTag = (title, className) => `


### PR DESCRIPTION
Closes: #204 

## Checklist

* [x] I made something good today 💐.
* [ ] I put links in the correct format: ``[Tool](link) — description.``
* [ ] My description starts with the lower-case letter and ends with the full stop.
* [ ] I put the tool in the alphabetical order.

## Optional

* [ ] I added the appropriate labels: free, open-source or mac.
* [ ] I put the tool only to one category.
* [x] I followed [Contribution Guidelines](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Contribution_Guidelines.md#one-tool-can-go-only-to-one-category). 

