### PR TITLE
Remove protowire + pointbreak

### DIFF
--- a/Awesome-Design-Plugins.md
+++ b/Awesome-Design-Plugins.md
@@ -596,7 +596,6 @@ If you found some great design tool or plugin, just send a Pull Request with res
 * [Auto Layout](https://animaapp.github.io/Auto-Layout/) — Responsive design inside Sketch. Design for all screen sizes on one artboard. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Sketch Constraints](https://github.com/bouchenoiremarc/Sketch-Constraints) — A plugin that integrates constraints in Sketch to lay out layers. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Pixel Perfect](https://github.com/materik/sketchplugin-pixelperfect) — Plugin for Sketch for handling layout and sizing of layers automatically based on their names. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
-* [Pointbreak](https://pointbreak.protowire.com) — Add breakpoints to artboards so you can have mobile and desktop designs on the one artboard. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Compo](https://github.com/romashamin/compo-sketch) — Makes it easier to work with interface components in Sketch ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Toggle Constrain Proportions](https://github.com/ErikFontanel/sketch-toggle-constrain-proportions) — Toggles the contrain proportions setting with keyboard shortcut ⌘ + P. Sketch v39+ compatible. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Method](https://github.com/KikeSz/Method-Sketch-Plugin) — Tool to apply your methodology systems ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
@@ -1022,7 +1021,6 @@ If you found some great design tool or plugin, just send a Pull Request with res
 <article id="prototyping">
 
 ### Prototyping
-* [Protowire](https://protowire.com) — Adds prototyping to Sketch including transitions between screens and layer animation. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Sketch Browser Preview](https://github.com/FreakLand/sketch-browser-preview) — Generates a preview (⌘ + ⇧ + .) of your current artboard and shows in your web browser. ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [AnimateMate](https://github.com/Creatide/AnimateMate) — Create your animations directly in Sketch ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)
 * [Prototypes Invision ↔︎ Sketch](https://github.com/mathieudutour/prototypes-invision-sketch) — Translate your prototyping links back and forth between Sketch and Invision ![sketch.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/sketch.svg)

--- a/docs/index-plugins.html
+++ b/docs/index-plugins.html
@@ -9744,27 +9744,6 @@ article ul {
 			</div>
 		</li>
 <li class="tool">
-			<a href="https://pointbreak.protowire.com" class="tool__asset" target="_blank" style="background-color: hsl(35.3, 95%, 81%); color: rgb(219, 173, 107);">P</a>
-			<div class="tool__description">
-				<header class="tool__description__header">
-					
-<p><a href="https://pointbreak.protowire.com" target="_blank">Pointbreak</a>
-					</p><div class="label-wrapper">
-						
-	<div class="label label--sketch" title="this plugin is for Sketch" for="sketch">
-		Sketch
-	</div>	
-
-					</div>
-				</header>
-				<p>Add breakpoints to artboards so you can have mobile and desktop designs on the one artboard. </p>
-<p></p>
-				<div class="tag-wrapper">
-					
-				</div>
-			</div>
-		</li>
-<li class="tool">
 			<a href="https://github.com/romashamin/compo-sketch" class="tool__asset" target="_blank" style="background-color: hsl(35.3, 95%, 81%); color: rgb(219, 173, 107);">C</a>
 			<div class="tool__description">
 				<header class="tool__description__header">
@@ -15851,27 +15830,6 @@ article ul {
 			</header>
 			<ul>
 				
-<li class="tool">
-			<a href="https://protowire.com" class="tool__asset" target="_blank" style="background-color: hsl(271.6, 77%, 81%); color: rgb(167, 116, 212);">P</a>
-			<div class="tool__description">
-				<header class="tool__description__header">
-					
-<p><a href="https://protowire.com" target="_blank">Protowire</a>
-					</p><div class="label-wrapper">
-						
-	<div class="label label--sketch" title="this plugin is for Sketch" for="sketch">
-		Sketch
-	</div>	
-
-					</div>
-				</header>
-				<p>Adds prototyping to Sketch including transitions between screens and layer animation. </p>
-<p></p>
-				<div class="tag-wrapper">
-					
-				</div>
-			</div>
-		</li>
 <li class="tool">
 			<a href="https://github.com/FreakLand/sketch-browser-preview" class="tool__asset" target="_blank" style="background-color: hsl(271.6, 77%, 81%); color: rgb(167, 116, 212);">SB</a>
 			<div class="tool__description">


### PR DESCRIPTION
Both Protowire and Pointbreak are no longer available according to their website(s).

- https://pointbreak.protowire.com
  > This plugin is no longer available to download.
- https://protowire.com
  > Protowire is no longer available for download. The plugin will continue to be updated to work with the latest version of Sketch for users with an active licence.


If you'd prefer to not have them removed (for reference), could there instead be some kind of "outdated" or "no longer available" system in place as a separate category?

## Checklist

* [ ] ~I made something good today 💐.~
* [ ] ~I put links in the correct format: ``[Tool](link) — description.``~
* [ ] ~My description starts with the lower-case letter and ends with the full stop.~
* [ ] ~I put the tool in the alphabetical order.~

## Optional

* [ ] ~I added the appropriate labels: free, open-source or mac.~
* [ ] ~I put the tool only to one category.~
* [x] I followed [Contribution Guidelines](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Contribution_Guidelines.md#one-tool-can-go-only-to-one-category). 

