### PR TITLE
Fix typo & broken link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5868,11 +5868,11 @@ article ul {
         </button>
     </a>
 </div></article>
-<article id="development-browsers">
+<article id="development-tools">
 			<header>
 				<h3><a href="#development-tools">Development Tools</a></h3>
 				
-<p>This section mentions developmenttools and browsers. Development browsers have features that help developers and designers create and test websites and apps.</p>
+<p>This section mentions development tools and browsers. Development browsers have features that help developers and designers create and test websites and apps.</p>
 
 			</header>
 			<ul>


### PR DESCRIPTION
The link to the development tools section was broken so I changed it to correspond with the destination of the link in its header. Also, I added a necessary space between two words ("development" and "tools").