### PR TITLE
Adds Tint & Shade Generator to Color Picker Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ If you are looking for an eyedropper tool, color identifier or color capture, ch
 - [Sip](https://sipapp.io/) — a better way to collect, organize and share colors. Global eyedropper tool for macOS. ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
 - [Skala Color](https://bjango.com/mac/skalacolor/) — works with a huge variety of formats, covering everything you’re likely to need for web, iOS, Android, and macOS development. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg) ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
 - [Swatches](https://swatchesapp.io/) — iOS app that lets you collect, inspect and share the colors that inspire you in your daily life. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg) ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
+- [Tint & Shade Generator](https://maketintsandshades.com/) — display tints and shades of a given hex color in 10% increments. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg) ![open-source.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/open-source.svg)
 - [Viz Palette](https://projects.susielu.com/viz-palette) — color picker for data visualizations. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
 
 <div class="banner banner--yellow">


### PR DESCRIPTION
This is just a link addition for https://maketintsandshades.com under Color Picker Tools.

## Checklist

* [x] I made something good today 💐.
* [x] I put links in the correct format: ``[Tool](link) — description.``
* [x] My description starts with the lower-case letter and ends with the full stop.
* [x] I put the tool in the alphabetical order.

## Optional

* [x] I added the appropriate labels: free, open-source or mac.
* [x] I put the tool only to one category.
* [x] I followed [Contribution Guidelines](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Contribution_Guidelines.md#one-tool-can-go-only-to-one-category). 

