### PR TITLE
Add imgi (free before/after image comparison tool)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,8 @@ You can also create color palettes with Leonardo, which is mentioned in the [Acc
 How do you provide and get feedback during the development process? This process is usually pretty messy for many product teams, which caused product delays and time waste on back-and-forth communication. So if you wish to get fast and structural feedback on UI issues or visual bugs — take a look at this tool:
 
 - [Flawless Feedback](https://flawlessapp.io/feedback) — review and annotate iOS apps then share your feedback in Jira or Trello. ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
-- [GoVisually](https://govisually.com) — online proofing, design review & approval software.
+- [GoVisually](https://govisually.com) — online proofing, design review & approval softwa
+- - [imgi](https://imgi.co) — compare two images with a before/after slider to review edits and gather visual feedback. Permanent share link, embed, and GIF/MP4 export. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)re.
   <div class="banner banner--yellow">
 
 </article>

--- a/README.md
+++ b/README.md
@@ -307,9 +307,9 @@ You can also create color palettes with Leonardo, which is mentioned in the [Acc
 How do you provide and get feedback during the development process? This process is usually pretty messy for many product teams, which caused product delays and time waste on back-and-forth communication. So if you wish to get fast and structural feedback on UI issues or visual bugs — take a look at this tool:
 
 - [Flawless Feedback](https://flawlessapp.io/feedback) — review and annotate iOS apps then share your feedback in Jira or Trello. ![mac.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/mac.svg)
-- [GoVisually](https://govisually.com) — online proofing, design review & approval softwa
-- - [imgi](https://imgi.co) — compare two images with a before/after slider to review edits and gather visual feedback. Permanent share link, embed, and GIF/MP4 export. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)re.
-  <div class="banner banner--yellow">
+- [GoVisually](https://govisually.com) — online proofing, design review & approval software.
+- - [imgi](https://imgi.co) — compare two images with a before/after slider to review edits and gather visual feedback. Permanent share link, embed, and GIF/MP4 export. ![free.svg](https://github.com/LisaDziuba/Awesome-Design-Tools/blob/master/Media/free.svg)
+  -   <div class="banner banner--yellow">
 
 </article>
 


### PR DESCRIPTION
Adds imgi ([imgi.co](https://imgi.co)) to the Design Feedback Tools section. imgi is a free web tool to compare two images with a before/after slider for reviewing edits and gathering visual feedback, with a permanent share link, an embed, and GIF/MP4 export. No signup. Placed after GoVisually to keep alphabetical order, labelled free, in a single category, following the contribution guidelines. Thanks for maintaining this list!